### PR TITLE
MethodError: Base.Broadcast.promote_containertype

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -11,6 +11,8 @@ Base.Broadcast.promote_containertype(::Type{T}, ::Type{S}) where {T<:AMSA, S<:Ab
 Base.Broadcast.promote_containertype(::Type{S}, ::Type{T}) where {T<:AMSA, S<:AbstractArray} = T
 Base.Broadcast.promote_containertype(::Type{T}, ::Type{<:Any}) where {T<:AMSA} = T
 Base.Broadcast.promote_containertype(::Type{<:Any}, ::Type{T}) where {T<:AMSA} = T
+Base.Broadcast.promote_containertype(::Type{T}, ::Type{S}) where {T<:AMSA, S<:AMSA} = T
+Base.Broadcast.promote_containertype(::Type{S}, ::Type{T}) where {T<:AMSA, S<:AMSA} = T
 Base.Broadcast._containertype(::Type{T}) where {T<:AMSA} = T
 Base.Broadcast.broadcast_indices(::Type{<:AMSA}, A) = indices(A)
 


### PR DESCRIPTION
While solving an ODEProblem, defined with a MultiScaleArrays I got this error message:

prob = ODEProblem(f, A_MultiScaleArrays, tspan)
solve(prob)

ERROR: MethodError: Base.Broadcast.promote_containertype(::Type{Container{Environment{MultiScaleArrays.AbstractMultiScaleArrayLeafWithInfofields{Float64},Float64},Float64}}, ::Type{Container{MultiScaleArrays.AbstractMultiScaleArray{Float64},Float64}}) is ambiguous. Candidates:                                                                                                                                                                                                                                                         
  promote_containertype(::Type{S}, ::Type{T}) where {T<:MultiScaleArrays.AbstractMultiScaleArray, S<:AbstractArray} in MultiScaleArrays at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:11                                                                       
  promote_containertype(::Type{#s2} where #s2, ::Type{T}) where T<:MultiScaleArrays.AbstractMultiScaleArray in MultiScaleArrays at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:13                                                                               
  promote_containertype(::Type{T}, ::Type{S}) where {T<:MultiScaleArrays.AbstractMultiScaleArray, S<:AbstractArray} in MultiScaleArrays at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:10                                                                       
Possible fix, define                                                                                                                                                                                                                                                   
  promote_containertype(::Type{T<:MultiScaleArrays.AbstractMultiScaleArray}, ::Type{S<:MultiScaleArrays.AbstractMultiScaleArray})                                                                                                                                      
 
I thus added 
Base.Broadcast.promote_containertype(::Type{T}, ::Type{S}) where {T<:AMSA, S<:AMSA} = T
Base.Broadcast.promote_containertype(::Type{S}, ::Type{T}) where {T<:AMSA, S<:AMSA} = T
to math.jl

Then I did
reload("MultiScaleArrays")
and got
INFO: Recompiling stale cache file /home/hmh/.julia/lib/v0.6/MultiScaleArrays.ji for module MultiScaleArrays.
WARNING: Method definition promote_containertype(Type{S<:(MultiScaleArrays.AbstractMultiScaleArray{B} where B)}, Type{T<:(MultiScaleArrays.AbstractMultiScaleArray{B} where B)}) in module MultiScaleArrays at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:14 overwritten at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:15.
WARNING: Method definition promote_containertype(Type{S<:(MultiScaleArrays.AbstractMultiScaleArray{B} where B)}, Type{T<:(MultiScaleArrays.AbstractMultiScaleArray{B} where B)}) in module MultiScaleArrays at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:14 overwritten at /home/hmh/.julia/v0.6/MultiScaleArrays/src/math.jl:15.
WARNING: replacing module MultiScaleArrays.

Then, it works, but I don't know why, and I hope it's right.
cheers
hugo