### PR TITLE
Bump version to v1.19.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiScaleArrays"
 uuid = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.18.0"
+version = "1.19.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
## Summary

- Bumps version from 1.18.0 to 1.19.0 to release changes already on master that were not included in any registered version:
  - PR #121: OrdinaryDiffEqDifferentiation compat bumped to include v2.0
  - PR #122: Fix deprecation warnings

## Motivation

The registered v1.18.0 has `OrdinaryDiffEqDifferentiation = "1.16.0 - 1"` in the registry, which caps OrdinaryDiffEqDifferentiation at v1.x. This prevents the Julia resolver from picking OrdinaryDiffEq v6.108 (which requires OrdinaryDiffEqDifferentiation v2) in any environment that includes MultiScaleArrays.

This is blocking DiffEqBase downstream CI from resolving OrdinaryDiffEqRosenbrock v1.24 (see https://github.com/SciML/DiffEqBase.jl/actions/runs/22308858783).

## After merge

Please register v1.19.0 with `@JuliaRegistrator register`.

## Test plan

- No code changes, just version bump — all code changes were already merged and tested in PRs #121 and #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)