### PR TITLE
Update RecursiveArrayTools compat to support v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiScaleArrays"
 uuid = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.19.0"
+version = "1.20.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -36,7 +36,7 @@ OrdinaryDiffEq = "6"
 OrdinaryDiffEqCore = "1.30.0, 2.0, 3.1"
 OrdinaryDiffEqDifferentiation = "1.16, 2.0"
 OrdinaryDiffEqRosenbrock = "1.17.0"
-RecursiveArrayTools = "1,2,3"
+RecursiveArrayTools = "1, 2, 3, 4"
 SciMLBase = "2.116"
 SparseDiffTools = "1.6, 2"
 Statistics = "1"

--- a/test/dynamic_diffeq.jl
+++ b/test/dynamic_diffeq.jl
@@ -87,7 +87,7 @@ sol = solve(
     tstops = tstop
 )
 
-@test length(sol[end]) == 17
+@test length(sol.u[end]) == 17
 
 println("Do the SDE Part")
 
@@ -115,7 +115,7 @@ sol = solve(prob, RKMil(), callback = growing_cb, dt = 1 / 10, tstops = tstop)
 
 sol = solve(prob, EM(), dt = 1 / 20, callback = growing_cb, tstops = tstop)
 
-@test length(sol[end]) == 23
+@test length(sol.u[end]) == 23
 
 @show SRIW1
 
@@ -133,4 +133,4 @@ sol = solve(prob, RKMil(), dt = 1 / 10, callback = shrinking_cb, tstops = tstop)
 
 sol = solve(prob, EM(), dt = 1 / 10, callback = shrinking_cb, tstops = tstop)
 
-@test length(sol[end]) == 17
+@test length(sol.u[end]) == 17

--- a/test/single_layer_diffeq.jl
+++ b/test/single_layer_diffeq.jl
@@ -53,7 +53,7 @@ sol = solve(prob, Tsit5(), callback = growing_cb, tstops = tstop)
 
 sol = solve(prob, Rosenbrock23(autodiff = AutoForwardDiff(chunksize = 1)), callback = growing_cb, tstops = tstop)
 
-@test length(sol[end]) == 13
+@test length(sol.u[end]) == 13
 
 affect_del! = function (integrator)
     return remove_node!(integrator, 1)
@@ -66,7 +66,7 @@ sol = solve(prob, Tsit5(), callback = shrinking_cb, tstops = tstop)
 
 prob = ODEProblem(f4, deepcopy(pop), (0.0, 1.0))
 sol = solve(prob, Rosenbrock23(autodiff = AutoForwardDiff(chunksize = 1)), callback = shrinking_cb, tstops = tstop)
-@test length(sol[end]) == 10
+@test length(sol.u[end]) == 10
 
 println("Do the SDE Part")
 
@@ -81,8 +81,8 @@ prob = SDEProblem(f4, g4, deepcopy(pop), (0.0, 1.0))
 
 sol = solve(prob, SOSRI(), callback = growing_cb, tstops = tstop)
 
-@test length(sol[end]) == 16
+@test length(sol.u[end]) == 16
 
 sol = solve(prob, SOSRI(), callback = shrinking_cb, tstops = tstop)
 
-@test length(sol[end]) == 10
+@test length(sol.u[end]) == 10


### PR DESCRIPTION
## Summary
- Bump RecursiveArrayTools compat to include v4
- RecursiveArrayTools v4 makes `AbstractVectorOfArray <: AbstractArray`

## Context
Part of the ecosystem-wide update for RecursiveArrayTools v4. The main breaking change is that `AbstractVectorOfArray` now subtypes `AbstractArray`, changing linear indexing behavior (`A[i]` returns scalar elements instead of inner arrays).

## Notes
- CI will fail until upstream deps (SciMLBase, DiffEqBase, OrdinaryDiffEq) also allow RAT v4
- Code/test changes may be needed for deprecated linear indexing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)