### PR TITLE
Bump DiffEqBase / OrdinaryDiffEq / OrdinaryDiffEqCore compat to include v7/v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiScaleArrays"
 uuid = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.21.0"
+version = "1.22.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -27,13 +27,13 @@ MultiScaleArraysSparseDiffToolsExt = "SparseDiffTools"
 
 [compat]
 ADTypes = "1"
-DiffEqBase = "6.5"
+DiffEqBase = "6.5, 7"
 DifferentiationInterface = "0.7.7"
 FiniteDiff = "2.3"
 ForwardDiff = "0.10, 1.3"
 JET = "0.9, 0.10, 0.11"
-OrdinaryDiffEq = "6"
-OrdinaryDiffEqCore = "1.30.0, 2.0, 3.1"
+OrdinaryDiffEq = "6, 7"
+OrdinaryDiffEqCore = "1.30.0, 2.0, 3.1, 4"
 OrdinaryDiffEqDifferentiation = "1.16, 2.0"
 OrdinaryDiffEqRosenbrock = "1.17.0"
 RecursiveArrayTools = "1, 2, 3, 4"


### PR DESCRIPTION
## Summary

Widen compat so MultiScaleArrays resolves alongside the v7 OrdinaryDiffEq stack (DiffEqBase 7.0.0, OrdinaryDiffEqCore 4.0.0, OrdinaryDiffEq 7.x):

- `DiffEqBase: "6.5"` → `"6.5, 7"`
- `OrdinaryDiffEq: "6"` → `"6, 7"`
- `OrdinaryDiffEqCore: "1.30.0, 2.0, 3.1"` → `"1.30.0, 2.0, 3.1, 4"`

Version bump 1.21.0 → 1.22.0.

## Already-OK

- `RecursiveArrayTools = "1, 2, 3, 4"` — already covers v4.
- `SciMLBase = "2.116, 3.0"` — already covers v3.
- `OrdinaryDiffEqDifferentiation = "1.16, 2.0"` — v2 already included.
- Other deps (`OrdinaryDiffEqRosenbrock = "1.17.0"`, `StochasticDiffEq = "6.13"`, `DifferentiationInterface = "0.7.7"`, etc.) — no v7-stack changes needed.

## Why this is source-level safe

Grepped `src/` clean for every symbol removed in the DiffEqBase v7 / SciMLBase v3 breaking notes: `u_modified!`, `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`. Zero matches.

## Motivation

On SciML/OrdinaryDiffEq.jl#3488 (the v7 release branch), `test (DiffEqBase_Downstream, 1)` fails with `Unsatisfiable requirements detected for package MultiScaleArrays` because the current `OrdinaryDiffEq = "6"` cap excludes the v7 stack that's path-sourced via `[sources]` in the monorepo.

Part of the broader v7 compat-widening set alongside DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71, ParameterizedFunctions#151, SciMLSensitivity#1431, Sundials#526, ODEInterfaceDiffEq#95, DiffEqFinancial#68, DiffEqPhysics#107, MethodOfLines#552, Catalyst#1463, LSODA#79.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>