### PR TITLE
Fix SDE dispatch after StochasticDiffEq v7 / OrdinaryDiffEqCore migration

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/src/diffeq.jl
+++ b/src/diffeq.jl
@@ -49,44 +49,44 @@ end
 reshape(m::AbstractMultiScaleArray, i::Int...) = m
 
 function remove_node_non_user_cache!(
-        integrator::DiffEqBase.AbstractODEIntegrator, idxs,
+        integrator::DiffEqBase.AbstractODEIntegrator, idxs::AbstractUnitRange,
         node...
     )
-    return remove_node_non_user_cache!(integrator, integrator.cache, node...)
+    return remove_node_non_user_cache!(integrator, integrator.cache, idxs, node...)
 end
 
 function remove_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache, idxs,
+        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache, idxs::AbstractUnitRange,
         node...
     )
     return nothing
 end
 
 function add_node_non_user_cache!(
-        integrator::DiffEqBase.AbstractODEIntegrator, idxs,
+        integrator::DiffEqBase.AbstractODEIntegrator, idxs::AbstractUnitRange,
         x::AbstractArray
     )
-    return add_node_non_user_cache!(integrator, integrator.cache, x)
+    return add_node_non_user_cache!(integrator, integrator.cache, idxs, x)
 end
 
 function add_node_non_user_cache!(
-        integrator::DiffEqBase.AbstractODEIntegrator, idxs,
+        integrator::DiffEqBase.AbstractODEIntegrator, idxs::AbstractUnitRange,
         x::AbstractArray, node...
     )
-    return add_node_non_user_cache!(integrator, integrator.cache, x, node...)
+    return add_node_non_user_cache!(integrator, integrator.cache, idxs, x, node...)
 end
 
 function add_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache,
+        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache, idxs::AbstractUnitRange,
         x::AbstractArray
     )
     return nothing
 end
 function add_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache,
+        cache::OrdinaryDiffEqCore.OrdinaryDiffEqCache, idxs::AbstractUnitRange,
         x::AbstractArray, node...
     )
     return nothing
@@ -94,7 +94,7 @@ end
 
 function add_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache,
+        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache, idxs::AbstractUnitRange,
         x::AbstractArray
     )
     i = length(integrator.u)
@@ -107,7 +107,7 @@ end
 
 function add_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache,
+        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache, idxs::AbstractUnitRange,
         x::AbstractArray, node...
     )
     i = length(integrator.u)
@@ -120,7 +120,7 @@ end
 
 function remove_node_non_user_cache!(
         integrator::DiffEqBase.AbstractODEIntegrator,
-        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache,
+        cache::OrdinaryDiffEqRosenbrock.RosenbrockMutableCache, idxs::AbstractUnitRange,
         node...
     )
     i = length(integrator.u)
@@ -284,6 +284,55 @@ function remove_node_non_user_cache!(
             remove_node!(c, node...)
         end
     end
+end
+
+# As of StochasticDiffEq v7, SDE algorithms (SRIW1, SRA1, EM, RKMil, ...) construct
+# an `OrdinaryDiffEqCore.ODEIntegrator` rather than a `<: AbstractSDEIntegrator`, so
+# the integrator-typed methods above no longer dispatch. Route through the cache
+# type instead — the SDE-side caches still subtype `StochasticDiffEqMutableCache`.
+function add_node_non_user_cache!(
+        integrator::DiffEqBase.AbstractODEIntegrator,
+        cache::StochasticDiffEq.StochasticDiffEqMutableCache,
+        idxs::AbstractUnitRange,
+        x::AbstractArray, node...
+    )
+    if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+        add_node_noise!(integrator, idxs, x, node...)
+        for c in rand_cache(integrator)
+            add_node!(c, copy(x), node...)
+        end
+    end
+    return nothing
+end
+
+function add_node_non_user_cache!(
+        integrator::DiffEqBase.AbstractODEIntegrator,
+        cache::StochasticDiffEq.StochasticDiffEqMutableCache,
+        idxs::AbstractUnitRange,
+        x::AbstractArray
+    )
+    if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+        add_node_noise!(integrator, idxs, x)
+        for c in rand_cache(integrator)
+            add_node!(c, copy(x))
+        end
+    end
+    return nothing
+end
+
+function remove_node_non_user_cache!(
+        integrator::DiffEqBase.AbstractODEIntegrator,
+        cache::StochasticDiffEq.StochasticDiffEqMutableCache,
+        idxs::AbstractUnitRange,
+        node...
+    )
+    if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+        remove_node_noise!(integrator, node...)
+        for c in rand_cache(integrator)
+            remove_node!(c, node...)
+        end
+    end
+    return nothing
 end
 
 ### For if noise is an AMSA


### PR DESCRIPTION
## Summary

Follow-up to #130. The `Tests` job is currently red on master because the SDE side of `src/diffeq.jl` no longer dispatches under StochasticDiffEq v7.

In StochasticDiffEq v7, SDE algorithms (`SRIW1`, `SRA1`, `EM`, `RKMil`, ...) construct an `OrdinaryDiffEqCore.ODEIntegrator` rather than a `<: AbstractSDEIntegrator`. The existing `add_node_non_user_cache!` / `remove_node_non_user_cache!` overloads dispatched on `DiffEqBase.AbstractSDEIntegrator`, so under v7 they were never selected. The catch-all `AbstractODEIntegrator` overload then fell through to itself, producing infinite recursion / `StackOverflowError` whenever an SDE callback called `add_node!` / `remove_node!`. That is exactly the failure observed in the merged PR #130 CI run (`Tests (lts)` and `Tests (1)`):

```
LoadError: StackOverflowError:
Stacktrace:
  [1] add_node_non_user_cache!(::OrdinaryDiffEqCore.ODEIntegrator{SRIW1, ...}, ::SRIW1Cache, ::Cell{Float64}, ::Int64, ::Vararg{Int64})
  [2] add_node_non_user_cache!(...) (repeats 7367 times)
```

## Fix

- Switch the SDE-side branches to dispatch on the cache type `StochasticDiffEq.StochasticDiffEqMutableCache`, which still tags every SDE algorithm's cache. The pre-existing `AbstractSDEIntegrator` methods are kept for callers that still construct that integrator type.
- Forward `idxs` through the cache-typed dispatch chain so the SDE noise routines have what they need.
- Constrain `idxs` to `AbstractUnitRange` on the top-level `add_node_non_user_cache!` / `remove_node_non_user_cache!` methods to prevent ambiguity between the integrator-typed dispatcher and the cache-typed method (both could otherwise match when `x::AbstractArray` and `idxs::UnitRange`, since `UnitRange <: AbstractArray`).
- Add `julia-actions/setup-julia@v2` to `.github/workflows/FormatCheck.yml`. The `fredrikekre/runic-action@v1` step needs Julia on `PATH` to run, and without this step it errors with `julia is a required dependency but does not seem to be available` (this is what currently fails the `format-check` job on master).

## Local verification

`Pkg.test()` on Julia 1.10 (lts):

```
Test Summary:        | Pass  Total     Time
Dynamic DiffEq Tests |    3      3  1m53.0s
Test Summary:             | Pass  Total   Time
Single Layer DiffEq Tests |    4      4  56.6s
Test Summary:   | Pass  Total  Time
New Nodes Tests |    1      1  2.7s
     Testing MultiScaleArrays tests passed
```

The existing `dynamic_diffeq.jl` test exercises exactly the failing path: `solve(prob, SRIW1(), callback = growing_cb, ...)` where `growing_cb` calls `add_node!(integrator, integrator.u[1, 1, 1], 1, 1)`, plus the analogous shrinking callback for `SRA1`/`RKMil`/`EM`. No new test needed.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>