### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,21 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the remaining inline CI to the centralized SciML reusable workflows (`@v1`), so every check is a central caller with `secrets: "inherit"`.

## Converted (inline -> central)
- **FormatCheck.yml** (`runic`): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml** (`typos-check`): inline `crate-ci/typos@v1.18.0` -> `spellcheck.yml@v1`
- **Downgrade.yml** (`downgrade`): inline `julia-downgrade-compat` -> `downgrade.yml@v1`, preserving `julia-version: "1.10"` and `skip: "Pkg,TOML"`

## Already central (left unchanged)
- **Tests.yml** -> `tests.yml@v1` (matrix `1`, `lts`, `pre`), already `secrets: "inherit"`
- **Documentation.yml** -> `documentation.yml@v1`, already `secrets: "inherit"`

## Other changes
- **dependabot.yml**: removed the `crate-ci/typos` version-ignore (no longer pinned inline); `github-actions` (weekly, `/`) and `julia` (daily, `all-julia-packages: ["*"]` over `/`, `/docs`, `/test`) blocks preserved.

## Not changed
- **QA.yml**: a custom Aqua/QA job (`test/qa`). There is no central QA caller, so it is left as-is.
- **TagBot.yml**: unchanged.
- No `CompatHelper.yml` present.

## Notes
- Runic ran clean (no formatting changes); the repo already ran Runic inline.
- `typos` ran clean (0 fixes needed).
- **Heads up:** check names change (e.g. `format-check / runic` -> the central `Runic Format Check` job name, spellcheck/downgrade job names change). Branch-protection required-status-check names will need updating accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)