### PR TITLE
Release prep: bump version to 2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiScaleArrays"
 uuid = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.24.2"
+version = "2.0.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "1"        
-MultiScaleArrays = "1.10"
+MultiScaleArrays = "1.10, 2"


### PR DESCRIPTION
## Summary

Bumps the package version from 1.24.2 to 2.0.0 to register the commits accumulated since the last release (1.24.2, commit 84ae79e).

### Changes since 1.24.2 (single commit: #149 "Use SciMLTesting 2.1 QA docs check")

- Adds docstrings for already-exported API (`AbstractMultiScaleArrayLeaf`, `AbstractMultiScaleArrayHead`, `add_node!`, `remove_node!`, `getindices`, `level_iter`, `LevelIterIdx`, `LevelIter`, `num_nodes`, `construct`) and renders them via the new SciMLTesting 2.1 QA docs check.
- Bumps the (test-only) `SciMLTesting` compat bound from `1.6` to `2.1`.
- **Stops exporting `recursivecopy!`** from `MultiScaleArrays`. This was an accidental re-export of `RecursiveArrayTools.recursivecopy!` that was never intended as MultiScaleArrays public API (see commit message on 643428c). Removing it from the export list means `using MultiScaleArrays; recursivecopy!(...)` (unqualified) will no longer resolve — callers need `using RecursiveArrayTools` (already a direct dependency) or to qualify the call. The accompanying test was updated to explicitly `using RecursiveArrayTools`.

### Why a MAJOR bump

Everything except the export removal is docs/test/CI-only (PATCH-level). However, removing a previously-exported symbol is a backward-incompatible change for any downstream code relying on the unqualified `recursivecopy!` binding. Since MultiScaleArrays is already past 1.0 (at 1.24.2), SemVer convention calls for a MAJOR bump for breaking changes rather than a MINOR bump (which only applies pre-1.0). Hence 1.24.2 → 2.0.0.

### Compat bounds

No SciML-ecosystem runtime compat lower bounds needed adjustment — the diff only touched the `SciMLTesting` bound, which is a test-only dependency (listed in `[extras]`/`[targets]`, not `[deps]`), and it was already updated to `2.1` in the source commit. No new APIs from `SciMLBase`/`DiffEqBase`/`OrdinaryDiffEq*`/`RecursiveArrayTools`/etc. are used in the diff, so their lower bounds were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)