### PR TITLE
Fix version: 1.25.0 not 2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiScaleArrays"
 uuid = "f9640e96-87f6-5992-9c3b-0743c6a49ffa"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.0.0"
+version = "1.25.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Correcting the release-prep version bump from #150. The recursivecopy! export removal was an accidental re-export cleanup, not an intentional breaking API change, so MINOR (1.25.0) is correct rather than MAJOR (2.0.0).