### PR TITLE
QA: document why the SparseDiffTools extension cannot be scanned

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,11 @@
 using SciMLTesting, MultiScaleArrays
 
+# ExplicitImports only sees an extension module once its trigger package is loaded, so QA
+# environments normally add the weakdeps here to bring the extensions into scope.
+#
+# MultiScaleArraysSparseDiffToolsExt stays unscanned: SparseDiffTools 2 caps SciMLOperators
+# at 0.4, while SciMLBase 3.28.1+ and OrdinaryDiffEqDifferentiation 3 (both hard deps)
+# require SciMLOperators 1.3+, so SparseDiffTools cannot be installed alongside
+# MultiScaleArrays at all and the extension can never load.
+
 run_qa(MultiScaleArrays)


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

## Context

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module. ExplicitImports
*does* know about package extensions — it reads the `[extensions]` table out of
`Project.toml` and adds each extension to the set of checked modules — but only when the
extension module actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger (weakdep) has been loaded, and QA
environments do not load weakdeps. So `MultiScaleArraysSparseDiffToolsExt` is not scanned
by QA today. The usual fix is to add the weakdeps to `test/qa/Project.toml` and `using`
them in `test/qa/qa.jl`.

## What this PR does

Only adds a comment, because **the usual fix is not applicable here**: `SparseDiffTools`
cannot be installed alongside `MultiScaleArrays` at all.

```
ERROR: Unsatisfiable requirements detected for package SciMLOperators [c0aeaf25]:
 SciMLOperators [c0aeaf25] log:
 ├─possible versions are: 0.1.0 - 1.25.2 or uninstalled
 ├─restricted by compatibility requirements with SciMLBase [0bca4576] to versions: 1.3.0 - 1.25.2
 │ └─SciMLBase [0bca4576] log:
 │   ├─possible versions are: 1.0.0 - 3.41.0 or uninstalled
 │   └─restricted to versions 3.28.1 - 3 by MultiScaleArrays [f9640e96], leaving only versions: 3.28.1 - 3.41.0
 ├─restricted by compatibility requirements with OrdinaryDiffEqDifferentiation [4302a76b] to versions: 1.15.0 - 1.25.2
 │ └─OrdinaryDiffEqDifferentiation [4302a76b] log:
 │   ├─possible versions are: 1.0.0 - 3.6.0 or uninstalled
 │   └─restricted to versions 3 by MultiScaleArrays [f9640e96], leaving only versions: 3.0.0 - 3.6.0
 └─restricted by compatibility requirements with SparseDiffTools [47a9eef4] to versions: 0.1.19 - 0.4.0 — no versions left
   └─SparseDiffTools [47a9eef4] log:
     ├─possible versions are: 0.1.0 - 2.26.0 or uninstalled
     ├─restricted to versions 2 by MultiScaleArrays [f9640e96], leaving only versions: 2.0.0 - 2.26.0 or uninstalled
```

`SparseDiffTools` 2.26 (the newest release; `[compat] SparseDiffTools = "2"` allows nothing
newer, and no 3.x exists) caps `SciMLOperators` at `0.4`, while the hard deps
`SciMLBase = "3.28.1"` and `OrdinaryDiffEqDifferentiation = "3"` both require
`SciMLOperators >= 1.3`. Adding `SparseDiffTools` to `test/qa/Project.toml` makes the QA
group fail to instantiate with the error above.

So this PR records *why* the weakdep is deliberately absent from `test/qa/Project.toml`, so
the next attempt does not repeat the resolve.

## Direct verification that the extension is not scanned

A passing QA summary would not prove anything either way (each ExplicitImports check folds
all submodules into a single `@test`), so this was checked directly from the QA
environment:

```
$ julia --project=test/qa -e '
    using SciMLTesting, MultiScaleArrays
    const EI = SciMLTesting.ExplicitImports
    println("Base.get_extension(MultiScaleArrays, :MultiScaleArraysSparseDiffToolsExt) => ",
            Base.get_extension(MultiScaleArrays, :MultiScaleArraysSparseDiffToolsExt))
    res = EI.explicit_imports(MultiScaleArrays)
    println("modules ExplicitImports scans => ", first.(res))'

Base.get_extension(MultiScaleArrays, :MultiScaleArraysSparseDiffToolsExt) => nothing
modules ExplicitImports scans => Module[MultiScaleArrays]
```

The extension module does not exist and only `MultiScaleArrays` itself is scanned — and it
cannot be made to exist, per the resolve failure above.

## Coverage

* Extensions now scanned: **none** (no change).
* Extensions still unscanned: `MultiScaleArraysSparseDiffToolsExt` — its trigger cannot
  co-resolve with the package's own hard dependencies.
* Ignore entries added to `ei_kwargs`: **none**.
* Extension source changed: **none**.

## Bigger finding: the extension looks like dead code

Two independent reasons, both a maintainer decision, deliberately *not* acted on here:

1. As shown above, `SparseDiffTools` cannot be loaded in any environment that also has
   `MultiScaleArrays`, so `MultiScaleArraysSparseDiffToolsExt` can never load for anyone.
2. The extension specialises `add_node_jac_config!` / `remove_node_jac_config!` on
   `SparseDiffTools.ForwardColorJacCache`, which is what `OrdinaryDiffEqDifferentiation`
   used to build for `cache.jac_config`. `OrdinaryDiffEqDifferentiation` dropped its
   `SparseDiffTools` dependency after v1.3 (v1.11 onward do not depend on it at all), so
   under the pinned `OrdinaryDiffEqDifferentiation = "3"` `cache.jac_config` is never a
   `ForwardColorJacCache`.

If that reading is right, the follow-up is to delete `ext/` along with the `[weakdeps]`,
`[extensions]` and `SparseDiffTools` `[compat]` entries — then the "unscanned extension"
problem disappears instead of being documented. Happy to do that as a separate PR.

## Local QA result

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on Julia 1.12.6:

```
ERROR: LoadError: Some tests did not pass: 16 passed, 1 failed, 3 errored, 0 broken.
```

**Identical on unmodified `master`** — verified by stashing this diff and re-running, same
`16 passed, 1 failed, 3 errored, 0 broken`. So the failures are pre-existing and unrelated
to this PR, which only adds a comment. They are:

* Aqua "Method ambiguity" — errors with `ERROR: ArgumentError: Package Aqua not found in
  current path` inside the subprocess `detect_ambiguities` spawns.
* Aqua "Compat bounds" — `MultiScaleArrays` deps missing `[compat]` entries for
  `LinearAlgebra` and `Random`.
* `all_qualified_accesses_are_public` — `Base.Broadcast.{AbstractArrayStyle, Broadcasted,
  DefaultArrayStyle, _broadcast_getindex_eltype}`, `ForwardDiff.{DerivativeConfig, Dual,
  Tag}`, `Base.typename`.
* `all_explicit_imports_are_public` — `RecursiveArrayTools.chain`.

All of these are in `src/`, none in `ext/`. Fixing them is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
